### PR TITLE
pre中在进行html格式化的时候带有换行

### DIFF
--- a/src/main/java/org/b3log/solo/plugin/list/ListHandler.java
+++ b/src/main/java/org/b3log/solo/plugin/list/ListHandler.java
@@ -16,6 +16,7 @@
 package org.b3log.solo.plugin.list;
 
 
+import org.apache.commons.lang.StringUtils;
 import org.b3log.latke.Latkes;
 import org.b3log.latke.event.AbstractEventListener;
 import org.b3log.latke.event.Event;
@@ -27,6 +28,7 @@ import org.json.JSONObject;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
 import org.jsoup.select.Elements;
 
 
@@ -34,7 +36,8 @@ import org.jsoup.select.Elements;
  * List (table of contents of an article) handler.
  *
  * @author <a href="http://88250.b3log.org">Liang Ding</a>
- * @version 1.0.0.0, May 30, 2014
+ * @author <a href="http://www.annpeter.cn">Ann Peter</a>
+ * @version 1.0.1.0, May 4, 2016
  * @since 0.6.7
  */
 public class ListHandler extends AbstractEventListener<JSONObject> {
@@ -56,7 +59,8 @@ public class ListHandler extends AbstractEventListener<JSONObject> {
 
         String content = article.optString(Article.ARTICLE_CONTENT);
 
-        final Document doc = Jsoup.parse(content);
+        final Document doc = Jsoup.parse(content, StringUtils.EMPTY, Parser.htmlParser());
+        doc.outputSettings().prettyPrint(false);
 
         final StringBuilder listBuilder = new StringBuilder();
 


### PR DESCRIPTION
pre中在进行html格式化的时候带有换行,导致pre中行高看起来特别高。


我们的博客总是会经常提交代码块的，在昨天提交的时候我发现博客中代码块的行高特别高，pre中在进行html格我把我的css样式翻了个遍，没有找到问题所在，后来经过各种手段确认不是css问题，而是在pre块中存在换行。

以下是一个简短的调试视频。
![此处输入图片的描述][1]

最终确定我还是拿出了神器Wireshark才最终确定，下面是关于这段代码在Wireshark中获取到的截图。
![此处输入图片的描述][2]

为了确认不是我输入的数据有问题，我还专程跑到数据库里看了一下，确认我没有输入换行。

最后确认系统中在进行html格式化的时候出现了问题。


找到问题就行了，Google到一下解决办法。

```java
//修改前的代码
Document doc = Jsoup.parse(content);

//修改后的代码
Document doc = Jsoup.parse(content, StringUtils.EMPTY, Parser.htmlParser());
doc.outputSettings().prettyPrint(false);
```

实际上就是让Jsoup在解析html的时候不进行美化直接输出。


  [1]: http://7xtmt1.com1.z0.glb.clouddn.com/b3log%EF%BC%8C%E8%BF%99%E6%AC%A1%E6%88%91%E5%BD%BB%E5%BA%95%E6%87%B5%E9%80%BC%E4%BA%86%E3%80%82%E3%80%82%E3%80%82.mp4
  [2]: http://7xtmt1.com1.z0.glb.clouddn.com/F5590079-E366-487F-B419-E0F1A67CF0BA.png