### PR TITLE
修改当static资源和主程序不在一台服务器上，静态资源加载出现bug

### DIFF
--- a/src/main/java/org/b3log/solo/plugin/list/ListHandler.java
+++ b/src/main/java/org/b3log/solo/plugin/list/ListHandler.java
@@ -64,7 +64,7 @@ public class ListHandler extends AbstractEventListener<JSONObject> {
 
         final StringBuilder listBuilder = new StringBuilder();
 
-        listBuilder.append("<link rel=\"stylesheet\" type=\"text/css\" href=\"" + Latkes.getStaticPath() + "/plugins/list/style.css\" />");
+        listBuilder.append("<link rel=\"stylesheet\" type=\"text/css\" href=\"" + Latkes.getStaticServePath() + "/plugins/list/style.css\" />");
 
         final Elements hs = doc.select("h1, h2, h3, h4, h5");
 


### PR DESCRIPTION
Latkes.getStaticPath()默认static资源和主程序在同一台服务器上，当我将所有静态文件都搬到七牛上时，出现bug；所以这里应该用Latkes.getStaticServePath()更合适。