### PR TITLE
解决多文件上传时,回填markdown是名称异常

### DIFF
--- a/src/main/webapp/js/admin/article.js
+++ b/src/main/webapp/js/admin/article.js
@@ -467,7 +467,7 @@ admin.article = {
                     return;
                 }
 
-                $('#articleUpload').after('<div id="uploadContent">![' + filename + '](http://'
+                $('#articleUpload').after('<div id="uploadContent">![' + data.files[0].name + '](http://'
                         + qiniu.qiniuDomain + qiniuKey + ')</div>');
             },
             fail: function (e, data) {


### PR DESCRIPTION
多文件选中一起传时，文件名称回显异常 fix
还有markdown渲染的时候图片宽度需要设置 width="100%", 否则 i-node 这个皮肤会使图片显示异常，这块最好解决下～～